### PR TITLE
Change venue models for new convention

### DIFF
--- a/app/src/main/java/in/ac/iitb/gymkhana/iitbapp/adapter/FeedAdapter.java
+++ b/app/src/main/java/in/ac/iitb/gymkhana/iitbapp/adapter/FeedAdapter.java
@@ -63,7 +63,7 @@ public class FeedAdapter extends RecyclerView.Adapter<FeedAdapter.ViewHolder> {
         }
         StringBuilder eventVenueName = new StringBuilder();
         for (Venue venue : currentEvent.getEventVenues()) {
-            eventVenueName.append(", ").append(venue.getVenueName());
+            eventVenueName.append(", ").append(venue.getVenueShortName());
         }
         if (!eventVenueName.toString().equals(""))
             viewHolder.eventVenue.setText(eventVenueName.toString().substring(2));

--- a/app/src/main/java/in/ac/iitb/gymkhana/iitbapp/data/Venue.java
+++ b/app/src/main/java/in/ac/iitb/gymkhana/iitbapp/data/Venue.java
@@ -16,6 +16,30 @@ public class Venue {
     @ColumnInfo(name = "name")
     @SerializedName("name")
     String venueName;
+    @ColumnInfo(name = "short_name")
+    @SerializedName("short_name")
+    String venueShortName;
+    @ColumnInfo(name = "description")
+    @SerializedName("description")
+    String venueDescripion;
+    @ColumnInfo(name = "parent")
+    @SerializedName("parent")
+    String venueParentId;
+    @ColumnInfo(name = "parent_relation")
+    @SerializedName("parent_relation")
+    String venueParentRelation;
+    @ColumnInfo(name = "group_id")
+    @SerializedName("group_id")
+    Integer venueGroupId;
+    @ColumnInfo(name = "pixel_x")
+    @SerializedName("pixel_x")
+    Integer venuePixelX;
+    @ColumnInfo(name = "pixel_y")
+    @SerializedName("pixel_y")
+    Integer venuePixelY;
+    @ColumnInfo(name = "reusable")
+    @SerializedName("reusable")
+    Boolean venueReusable;
     @ColumnInfo(name = "lat")
     @SerializedName("lat")
     double venueLatitude;
@@ -23,9 +47,17 @@ public class Venue {
     @SerializedName("lng")
     double venueLongitude;
 
-    public Venue(String venueID, String venueName, double venueLatitude, double venueLongitude) {
+    public Venue(String venueID, String venueName, String venueShortName, String venueDescripion, String venueParentId, String venueParentRelation, Integer venueGroupId, Integer venuePixelX, Integer venuePixelY, Boolean venueReusable, double venueLatitude, double venueLongitude) {
         this.venueID = venueID;
         this.venueName = venueName;
+        this.venueShortName = venueShortName;
+        this.venueDescripion = venueDescripion;
+        this.venueParentId = venueParentId;
+        this.venueParentRelation = venueParentRelation;
+        this.venueGroupId = venueGroupId;
+        this.venuePixelX = venuePixelX;
+        this.venuePixelY = venuePixelY;
+        this.venueReusable = venueReusable;
         this.venueLatitude = venueLatitude;
         this.venueLongitude = venueLongitude;
     }
@@ -60,5 +92,69 @@ public class Venue {
 
     public void setVenueLongitude(double venueLongitude) {
         this.venueLongitude = venueLongitude;
+    }
+
+    public String getVenueShortName() {
+        return venueShortName;
+    }
+
+    public void setVenueShortName(String venueShortName) {
+        this.venueShortName = venueShortName;
+    }
+
+    public String getVenueDescripion() {
+        return venueDescripion;
+    }
+
+    public void setVenueDescripion(String venueDescripion) {
+        this.venueDescripion = venueDescripion;
+    }
+
+    public String getVenueParentId() {
+        return venueParentId;
+    }
+
+    public void setVenueParentId(String venueParentId) {
+        this.venueParentId = venueParentId;
+    }
+
+    public String getVenueParentRelation() {
+        return venueParentRelation;
+    }
+
+    public void setVenueParentRelation(String venueParentRelation) {
+        this.venueParentRelation = venueParentRelation;
+    }
+
+    public Integer getVenueGroupId() {
+        return venueGroupId;
+    }
+
+    public void setVenueGroupId(Integer venueGroupId) {
+        this.venueGroupId = venueGroupId;
+    }
+
+    public Integer getVenuePixelX() {
+        return venuePixelX;
+    }
+
+    public void setVenuePixelX(Integer venuePixelX) {
+        this.venuePixelX = venuePixelX;
+    }
+
+    public Integer getVenuePixelY() {
+        return venuePixelY;
+    }
+
+    public void setVenuePixelY(Integer venuePixelY) {
+        this.venuePixelY = venuePixelY;
+    }
+
+    public Boolean getVenueReusable() {
+        return venueReusable;
+    }
+
+    public void setVenueReusable(Boolean venueReusable) {
+        this.venueReusable = venueReusable;
     }
 }

--- a/app/src/main/java/in/ac/iitb/gymkhana/iitbapp/fragment/EventFragment.java
+++ b/app/src/main/java/in/ac/iitb/gymkhana/iitbapp/fragment/EventFragment.java
@@ -102,7 +102,7 @@ public class EventFragment extends BaseFragment implements View.OnClickListener 
         StringBuilder eventVenueName = new StringBuilder();
 
         for (Venue venue : event.getEventVenues()) {
-            eventVenueName.append(", ").append(venue.getVenueName());
+            eventVenueName.append(", ").append(venue.getVenueShortName());
         }
 
        /* if(((LinearLayout) getActivity().findViewById(R.id.body_container)).getChildCount() == 0) {


### PR DESCRIPTION
The new convention tries to stick to the format of locations used by instiMAP for consistency, which includes using `short_name` for names like VMCC and `name` for Victor Menezes Convention Center. We want to show `short_name` to the user everywhere.