### PR TITLE
Remove cardCornerRadius from body/event headers

### DIFF
--- a/app/src/main/res/layout/fragment_body.xml
+++ b/app/src/main/res/layout/fragment_body.xml
@@ -40,7 +40,8 @@
                     <android.support.v7.widget.CardView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        app:cardBackgroundColor="@color/colorPrimary">
+                        app:cardBackgroundColor="@color/colorPrimary"
+                        app:cardCornerRadius="0dp">
 
                         <LinearLayout
                             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_event.xml
+++ b/app/src/main/res/layout/fragment_event.xml
@@ -36,7 +36,8 @@
                     <android.support.v7.widget.CardView
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        app:cardBackgroundColor="@color/colorPrimary">
+                        app:cardBackgroundColor="@color/colorPrimary"
+                        app:cardCornerRadius="0dp">
 
                         <LinearLayout
                             android:layout_width="match_parent"


### PR DESCRIPTION
Fixes the 1px gap between feature image and the header on all phones.