### PR TITLE
Download images on background thread in sync, fix notification image cache

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:name="app.insti.InstiAppApplication">
 
         <meta-data
             android:name="com.google.android.gms.version"

--- a/app/src/main/java/app/insti/InstiAppApplication.java
+++ b/app/src/main/java/app/insti/InstiAppApplication.java
@@ -1,0 +1,34 @@
+package app.insti;
+
+import android.app.Application;
+
+import com.squareup.picasso.Picasso;
+
+import java.io.File;
+
+import okhttp3.Cache;
+import okhttp3.OkHttpClient;
+
+public class InstiAppApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        try {
+            initPicasso();
+        } catch (IllegalStateException ignored) {}
+    }
+
+    public void initPicasso() {
+        Picasso.Builder builder = new Picasso.Builder(getApplicationContext());
+        OkHttpClient.Builder client = new OkHttpClient.Builder();
+        Cache cache = new Cache(new File(getApplicationContext().getCacheDir(), "http-cache"), 100 * 1024 * 1024);
+        client.cache(cache);
+        builder.downloader(new com.squareup.picasso.OkHttp3Downloader((
+                client.build()
+        )));
+        Picasso built = builder.build();
+        built.setIndicatorsEnabled(false);
+        built.setLoggingEnabled(false);
+        Picasso.setSingletonInstance(built);
+    }
+}

--- a/app/src/main/java/app/insti/InstiAppFirebaseMessagingService.java
+++ b/app/src/main/java/app/insti/InstiAppFirebaseMessagingService.java
@@ -130,46 +130,37 @@ public class InstiAppFirebaseMessagingService extends FirebaseMessagingService {
             final Context context, final String imageUrl, final String largeIconUrl,
             final int notification_id, final NotificationCompat.Builder builder, final String content){
 
-        new AsyncTask<Void, Void, Bitmap[]>() {
-            @Override
-            protected Bitmap[] doInBackground(Void... params) {
-                try {
-                    Bitmap image = null;
-                    if (imageUrl != null) {
-                        image = Picasso.get().load(imageUrl).get();
-                    }
-                    Bitmap largeIcon = null;
-                    if (largeIconUrl != null) {
-                         largeIcon = getCroppedBitmap(
-                                 Picasso.get().load(Constants.resizeImageUrl(largeIconUrl, 200)).get(), 200);
-                    }
-                    return new Bitmap[]{image, largeIcon};
-                } catch (IOException e) {
-                    e.printStackTrace();
+            Bitmap[] bitmaps = null;
+            try {
+                Bitmap image = null;
+                if (imageUrl != null) {
+                    image = Picasso.get().load(imageUrl).get();
                 }
-                return null;
+                Bitmap largeIcon = null;
+                if (largeIconUrl != null) {
+                     largeIcon = getCroppedBitmap(
+                             Picasso.get().load(Constants.resizeImageUrl(largeIconUrl, 200)).get(), 200);
+                }
+                bitmaps = new Bitmap[]{image, largeIcon};
+            } catch (IOException e) {
+                e.printStackTrace();
             }
 
-            @Override
-            protected void onPostExecute(Bitmap[] bitmaps) {
-                // Check if we loaded big image
-                if (bitmaps != null && bitmaps[0] != null) {
-                    builder.setStyle(
-                            new NotificationCompat.BigPictureStyle()
-                                    .bigPicture(bitmaps[0])
-                                    .setSummaryText(content)
-                    );
-                }
-
-                // Check if we loaded large icon
-                if (bitmaps != null && bitmaps[1] != null) {
-                    builder.setLargeIcon(bitmaps[1]);
-                }
-
-                showNotification(context, notification_id, builder.build());
-                super.onPostExecute(bitmaps);
+            // Check if we loaded big image
+            if (bitmaps != null && bitmaps[0] != null) {
+                builder.setStyle(
+                        new NotificationCompat.BigPictureStyle()
+                                .bigPicture(bitmaps[0])
+                                .setSummaryText(content)
+                );
             }
-        }.execute();
+
+            // Check if we loaded large icon
+            if (bitmaps != null && bitmaps[1] != null) {
+                builder.setLargeIcon(bitmaps[1]);
+            }
+
+            showNotification(context, notification_id, builder.build());
     }
 
     /** Get circular center cropped bitmap */

--- a/app/src/main/java/app/insti/InstiAppFirebaseMessagingService.java
+++ b/app/src/main/java/app/insti/InstiAppFirebaseMessagingService.java
@@ -13,7 +13,6 @@ import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
 import android.media.RingtoneManager;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;

--- a/app/src/main/java/app/insti/activity/MainActivity.java
+++ b/app/src/main/java/app/insti/activity/MainActivity.java
@@ -38,7 +38,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.squareup.picasso.Picasso;
 
-import java.io.File;
 import java.util.List;
 
 import app.insti.Constants;
@@ -47,12 +46,12 @@ import app.insti.SessionManager;
 import app.insti.api.EmptyCallback;
 import app.insti.api.RetrofitInterface;
 import app.insti.api.ServiceGenerator;
-import app.insti.api.request.UserFCMPatchRequest;
 import app.insti.api.model.Body;
 import app.insti.api.model.Event;
 import app.insti.api.model.Notification;
 import app.insti.api.model.Role;
 import app.insti.api.model.User;
+import app.insti.api.request.UserFCMPatchRequest;
 import app.insti.fragment.BackHandledFragment;
 import app.insti.fragment.BodyFragment;
 import app.insti.fragment.CalendarFragment;
@@ -68,8 +67,6 @@ import app.insti.fragment.QuickLinksFragment;
 import app.insti.fragment.SettingsFragment;
 import app.insti.fragment.TrainingBlogFragment;
 import app.insti.fragment.UserFragment;
-import okhttp3.Cache;
-import okhttp3.OkHttpClient;
 import retrofit2.Call;
 import retrofit2.Response;
 
@@ -116,10 +113,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        try {
-            initPicasso();
-        } catch (IllegalStateException ignored) {
-        }
 
         ServiceGenerator serviceGenerator = new ServiceGenerator(getApplicationContext());
         this.retrofitInterface = serviceGenerator.getRetrofitInterface();
@@ -606,20 +599,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     public String getSessionIDHeader() {
         return "sessionid=" + session.getSessionID();
-    }
-
-    public void initPicasso() {
-        Picasso.Builder builder = new Picasso.Builder(getApplicationContext());
-        OkHttpClient.Builder client = new OkHttpClient.Builder();
-        Cache cache = new Cache(new File(getApplicationContext().getCacheDir(), "http-cache"), 100 * 1024 * 1024);
-        client.cache(cache);
-        builder.downloader(new com.squareup.picasso.OkHttp3Downloader((
-                client.build()
-        )));
-        Picasso built = builder.build();
-        built.setIndicatorsEnabled(false);
-        built.setLoggingEnabled(false);
-        Picasso.setSingletonInstance(built);
     }
 
     @Override


### PR DESCRIPTION
> 76366bc - Do not create AsyncTask in background process
> f04e640 - Move creation of singleton Picasso to Application onCreate.
This allows using cached images for notifications