### PR TITLE
Setup automatic lint with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+        - run:
+          name: Run Lint
+          command: ./gradlew lint
       - store_artifacts:
           path: app/build/reports
           destination: reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/code
+    docker:
+      - image: circleci/android:api-28-alpha
+    environment:
+      JVM_OPTS: -Xmx3200m
+    steps:
+      - checkout
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+      - run:
+          name: Download Dependencies
+          command: ./gradlew androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+      - store_artifacts:
+          path: app/build/reports
+          destination: reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
-        - run:
+      - run:
           name: Run Lint
           command: ./gradlew lint
       - store_artifacts:


### PR DESCRIPTION
A few notes:
1) CircleCI will only check for build errors and whether all dependencies can be satisfied with `./gradlew lint`.
2) CircleCI will need to be enabled on the repository.
3) Successfully builds at [my fork](https://github.com/pulsejet/InstiApp/commits/master) and fails build on [this pull request](https://github.com/pulsejet/InstiApp/pull/1) as expected
4) This PR meant to be squash-merged
5) Todo: Add a `build:passing` label to README if this is setup